### PR TITLE
Replaced expected_authority_names with requirement string

### DIFF
--- a/MacVector/MacVector.download.recipe
+++ b/MacVector/MacVector.download.recipe
@@ -59,12 +59,10 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/MacVector.app</string>
-				<key>expected_authority_names</key>
-				<array>
-					<string>Developer ID Application: MACVECTOR INC</string>
-					<string>Developer ID Certification Authority</string>
-					<string>Apple Root CA</string>
-				</array>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.macvector.MacVector" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = BK85R8X44N)</string>
+				<key>strict_verification</key>
+				<true />
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
Using `expected_authority_names` with .app bundles is not supported in AutoPkg 1.0.3.