### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Airtool/Airtool.download.recipe
+++ b/Airtool/Airtool.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Airtool.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.adriangranados.Airtool" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2B9R362QNU")</string>
 			</dict>

--- a/Airtool/Airtool.install.recipe
+++ b/Airtool/Airtool.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Airtool.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/WiFi Explorer/WiFi Explorer.download.recipe
+++ b/WiFi Explorer/WiFi Explorer.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/WiFi Explorer.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier wifiexplorer and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2B9R362QNU")</string>
 			</dict>

--- a/WiFi Explorer/WiFi Explorer.install.recipe
+++ b/WiFi Explorer/WiFi Explorer.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>WiFi Explorer.app</string>
 					</dict>
 				</array>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.