### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Webex Teams/Webex Teams.pkg.recipe
+++ b/Webex Teams/Webex Teams.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.golbiga.pkg.WebexTeams</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>Cisco-Systems.Spark</string>
 		<key>NAME</key>
 		<string>Webex Teams</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ❌ Webex Teams/Webex Teams.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/golbiga-recipes/Webex\ Teams/Webex\ Teams.pkg.recipe
Processing repos/golbiga-recipes/Webex Teams/Webex Teams.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Webex Teams.dmg',
           'url': 'http://www.webex.com/downloads/WebexTeams.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.golbiga.pkg.WebexTeams/downloads/Webex Teams.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.golbiga.pkg.WebexTeams/downloads/Webex '
                        'Teams.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.golbiga.pkg.WebexTeams/downloads/Webex '
                         'Teams.dmg/Webex Teams.app',
           'requirement': 'identifier "Cisco-Systems.Spark" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'DE8Y96K9QP'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.golbiga.pkg.WebexTeams/downloads/Webex Teams.dmg
Receipt written to ~/Library/AutoPkg/Cache/com.github.golbiga.pkg.WebexTeams/receipts/Webex Teams.pkg-receipt-20210213-225228.plist

The following recipes failed:
    repos/golbiga-recipes/Webex Teams/Webex Teams.pkg.recipe
        Error in com.github.golbiga.pkg.WebexTeams: Processor: CodeSignatureVerifier: Error: Error processing path '/private/tmp/dmg.GMGZdi/Webex Teams.app' with glob. 

Nothing downloaded, packaged or imported.
```

