### PR TITLE
Change parent recipe for cgerke-recipes deprecation

### DIFF
--- a/JSS/CitrixReceiver.jss.recipe
+++ b/JSS/CitrixReceiver.jss.recipe
@@ -33,7 +33,7 @@
         <key>MinimumVersion</key>
         <string>0.4.0</string>
         <key>ParentRecipe</key>
-        <string>com.github.autopkg.cgerke-recipes.pkg.CitrixReceiver</string>
+        <string>com.github.homebysix.pkg.CitrixReceiver</string>
         <key>Process</key>
         <array>
             <dict>


### PR DESCRIPTION
The parent recipe has been copied to homebysix-recipes in order to prepare for cgerke-recipes deprecation. For details, see: autopkg/cgerke-recipes#37

