### PR TITLE
Update Webex Teams app name to Webex

### DIFF
--- a/Webex Teams/Webex Teams.download.recipe
+++ b/Webex Teams/Webex Teams.download.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Webex Teams.app</string>
+				<string>%pathname%/Webex.app</string>
 				<key>requirement</key>
 				<string>identifier "Cisco-Systems.Spark" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = DE8Y96K9QP</string>
 			</dict>
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/Webex Teams.app/Contents/Info.plist</string>
+				<string>%pathname%/Webex.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Webex Teams/Webex Teams.install.recipe
+++ b/Webex Teams/Webex Teams.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>Webex Teams.app</string>
+						<string>Webex.app</string>
 					</dict>
 				</array>
 			</dict>


### PR DESCRIPTION
The Webex Teams app is now just called Webex. Code signature requirements have not changed.
