### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Airtool/Airtool.pkg.recipe
+++ b/Airtool/Airtool.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/MacVector/MacVector.pkg.recipe
+++ b/MacVector/MacVector.pkg.recipe
@@ -70,8 +70,6 @@
 						<string>%version%</string>
 						<key>id</key>
 						<string>com.macvector.MacVector</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>chown</key>
 						<array>
 							<dict>

--- a/TextMate2/TextMate2.pkg.recipe
+++ b/TextMate2/TextMate2.pkg.recipe
@@ -70,8 +70,6 @@
 						<string>2.0</string>
 						<key>id</key>
 						<string>com.macromates.TextMate.preview</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>scripts</key>
 						<string>Scripts</string>
 						<key>chown</key>

--- a/WiFi Explorer/WiFi Explorer.pkg.recipe
+++ b/WiFi Explorer/WiFi Explorer.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._